### PR TITLE
updating recommended list

### DIFF
--- a/docs/pages/tools/integration/feast.md
+++ b/docs/pages/tools/integration/feast.md
@@ -3,7 +3,6 @@ title: "Feast"
 description: "Feast is an open-source feature store for machine learning."
 tags: "python, third party tools, machine learning"
 icon: "https://awesome-astra.github.io/docs/img/feast/feast.svg"
-recommended: "true"
 developer_title: "Tecton"
 developer_url: "https://feast.dev"
 links:

--- a/docs/pages/tools/integration/microsoft-powerquery.md
+++ b/docs/pages/tools/integration/microsoft-powerquery.md
@@ -3,7 +3,6 @@ title: "Microsoft Power Query"
 description: "Microsoft Power Query ..."
 tags: "microsoft, third party tools, etl, workflow, powerbi"
 icon: "https://awesome-astra.github.io/docs/img/microsoft-powerquery/microsoft-powerquery.svg"
-recommended: "true"
 developer_title: "Microsoft"
 developer_url: "https://powerquery.microsoft.com/en-us/"
 links:


### PR DESCRIPTION
Removed the recommended tags from PowerQuery and Feast.

Recommended will now be langchain, llamaindex, and dataflow